### PR TITLE
Switching file names and descriptions from ASCII to UTF-8

### DIFF
--- a/app/src/main/java/net/exclaimindustries/geohashdroid/wiki/WikiUtils.java
+++ b/app/src/main/java/net/exclaimindustries/geohashdroid/wiki/WikiUtils.java
@@ -476,8 +476,8 @@ public class WikiUtils {
         // TOKEN GET!  Now we've got us enough to get our upload on!
         MultipartEntityBuilder builder = MultipartEntityBuilder.create()
                 .addPart("action", new StringBody("upload", ContentType.TEXT_PLAIN))
-                .addPart("filename", new StringBody(filename, ContentType.TEXT_PLAIN))
-                .addPart("comment", new StringBody(description, ContentType.TEXT_PLAIN))
+                .addPart("filename", new StringBody(filename, ContentType.create("text/plain", "utf-8")))
+                .addPart("comment", new StringBody(description, ContentType.create("text/plain", "utf-8")))
                 .addPart("watch", new StringBody("true", ContentType.TEXT_PLAIN))
                 .addPart("ignorewarnings", new StringBody("true", ContentType.TEXT_PLAIN))
                 .addPart("token", new StringBody(token, ContentType.TEXT_PLAIN))


### PR DESCRIPTION
**Problem:** 

In the current version, file names and descriptions cannot contain special characters. For file names, this is relevant when the uploader's user name contains special characters. Special characters are replaced by a question mark ('?').

However, when including the file on the expedition page, unicode is used for file names and descriptions. This discrepancy leads to dead links.

For example: A user named 'π π π' uploaded this file, notice how 'π π π' is replaced by '? ? ?', or %3F URL encoded.

https://geohashing.site/geohashing/File:2022-02-09_53_10_%3F_%3F_%3F_1644614769193.jpg

On the expedition page, the file is included using 'π π π', resulting in dead links:

https://geohashing.site/index.php?title=2022-02-09_53_10&curid=291941&diff=829725&oldid=829723

(And a seemingly disappointed revert, "seems it didn't work with the Droid?": https://geohashing.site/index.php?title=2022-02-09_53_10&diff=next&oldid=829725)

**Solution:**

This pull request fixes the problem. I have tested the commit by uploading the following file with a test user named 'I ❤️ Unicode':

https://geohashing.site/geohashing/File:2012-07-22_55_-17_I_%E2%9D%A4%EF%B8%8F_Unicode_1644623971006.jpg

**Request and thank you:**

I would like to request that you will merge this commit into the main app.

Thank you for developing and maintaining it so well over the years, it is a very important tool for Geohashers.