### PR TITLE
solve issue of low contrast

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -6,7 +6,7 @@
         <item name="android:textSize">13sp</item>
         <item name="android:textAllCaps">true</item>
         <item name="android:fontFamily">sans-serif-medium</item>
-        <item name="android:textColor">#009688</item>
+        <item name="android:textColor">#0064FF</item>
     </style>
 
     <!-- This is for any Activity-that-looks-like-a-dialog. -->


### PR DESCRIPTION
The original text color of the component is '#009688', and the contrast between the text color ('#BEBEBE') and the background color ('#FFFFFFF') does not meet the standard of WCAG 2.1. In other words, this color cannot be easily seen by everyone. So, to solve this problem, our team designed a tool that can automatically detect and repair such problems. The test report and recommended replacement colors ('#0064FF') are as follows:
![image](https://user-images.githubusercontent.com/101503193/158519111-a3613d27-e9e9-4b90-9b92-0b1538921a9f.png)
The figure on the left is the original page, the figure on the right is the repaired page, and the figure below is the problem detection report.
If you think it is useful, please give me feedback. Your feedback is very important to me. We sincerely hope to receive your suggestions and opinions as an app developer.